### PR TITLE
Change 'status' block property name to 'status_update'

### DIFF
--- a/tests/test_twitter_post_block.py
+++ b/tests/test_twitter_post_block.py
@@ -12,7 +12,7 @@ class TestTwitterPost(NIOBlockTestCase):
         signals = [Signal({'foo': 'test signal'})]
         blk = TwitterPost()
         self.configure_block(blk, {
-            "status": "{{$foo}}"
+            "status_update": "{{$foo}}"
         })
         blk.start()
         self.assertEqual(mock_auth.call_count, 1)
@@ -31,7 +31,7 @@ class TestTwitterPost(NIOBlockTestCase):
         ]
         blk = TwitterPost()
         self.configure_block(blk, {
-            "status": "{{$foo}}"
+            "status_update": "{{$foo}}"
         })
         blk.start()
         self.assertEqual(mock_auth.call_count, 1)

--- a/twitter_post_block.py
+++ b/twitter_post_block.py
@@ -21,11 +21,11 @@ class TwitterPost(TwitterRestBase):
                 self.logger.exception("Status evaluation failed")
                 continue
 
-            data = {'status_update': status_update}
+            data = {'status': status_update}
             self._post_tweet(data)
 
     def _post_tweet(self, payload):
-        response = requests.post(POST_URL, data={'status':payload['status_update']}, auth=self._auth)
+        response = requests.post(POST_URL, data=payload, auth=self._auth)
         status = response.status_code
         if status != 200:
             try:
@@ -39,4 +39,4 @@ class TwitterPost(TwitterRestBase):
                 self.logger.exception("Failed to process error response")
         else:
             self.logger.debug(
-                "Posted '{0}' to Twitter!".format(payload['status_update']))
+                "Posted '{0}' to Twitter!".format(payload['status']))

--- a/twitter_post_block.py
+++ b/twitter_post_block.py
@@ -26,6 +26,7 @@ class TwitterPost(TwitterRestBase):
 
     def _post_tweet(self, payload):
         response = requests.post(POST_URL, data=payload, auth=self._auth)
+
         status = response.status_code
         if status != 200:
             try:

--- a/twitter_post_block.py
+++ b/twitter_post_block.py
@@ -11,22 +11,21 @@ POST_URL = "https://api.twitter.com/1.1/statuses/update.json"
 @discoverable
 class TwitterPost(TwitterRestBase):
 
-    status = Property(default='', title='Status Update')
+    status_update = Property(default='', title='Status Update')
 
     def process_signals(self, signals):
         for s in signals:
             try:
-                status = self.status(s)
+                status_update = self.status_update(s)
             except Exception:
                 self.logger.exception("Status evaluation failed")
                 continue
 
-            data = {'status': status}
+            data = {'status_update': status_update}
             self._post_tweet(data)
 
     def _post_tweet(self, payload):
-        response = requests.post(POST_URL, data=payload, auth=self._auth)
-
+        response = requests.post(POST_URL, data={'status':payload['status_update']}, auth=self._auth)
         status = response.status_code
         if status != 200:
             try:
@@ -40,4 +39,4 @@ class TwitterPost(TwitterRestBase):
                 self.logger.exception("Failed to process error response")
         else:
             self.logger.debug(
-                "Posted '{0}' to Twitter!".format(payload['status']))
+                "Posted '{0}' to Twitter!".format(payload['status_update']))


### PR DESCRIPTION
When the block property was named `status` the name conflicted with the `status` variable in base block